### PR TITLE
サロゲートペアを扱うテストケースを追加

### DIFF
--- a/src/test/java/nablarch/core/message/MessageUtilTest.java
+++ b/src/test/java/nablarch/core/message/MessageUtilTest.java
@@ -54,12 +54,12 @@ public class MessageUtilTest {
     @Test
     public void testGetSarogetoPeaMessageObject() throws Exception {
 
-        StringResource messageObject = MessageUtil.getStringResource("sarogetopea");
-        assertThat(messageObject.getId(), is("sarogetopea"));
+        StringResource messageObject = MessageUtil.getStringResource("surrogatepair");
+        assertThat(messageObject.getId(), is("surrogatepair"));
         assertThat(messageObject.getValue(Locale.JAPANESE), is("🙀𪛊"));
 
         Message message = MessageUtil.createMessage(MessageLevel.INFO, "message.with.placeholder",
-                MessageUtil.createMessage(MessageLevel.INFO, "sarogetopea.message"), "🙀🙀🙀");
+                MessageUtil.createMessage(MessageLevel.INFO, "surrogatepair.message"), "🙀🙀🙀");
         assertThat(message.formatMessage(Locale.JAPANESE), is("ここにmessageのメッセージが入る→𪛊𪛊𪛊-🙀🙀🙀"));
     }
 

--- a/src/test/java/nablarch/core/message/MessageUtilTest.java
+++ b/src/test/java/nablarch/core/message/MessageUtilTest.java
@@ -49,6 +49,21 @@ public class MessageUtilTest {
     }
 
     /**
+     * サロゲートペア対応
+     */
+    @Test
+    public void testGetSarogetoPeaMessageObject() throws Exception {
+
+        StringResource messageObject = MessageUtil.getStringResource("sarogetopea");
+        assertThat(messageObject.getId(), is("sarogetopea"));
+        assertThat(messageObject.getValue(Locale.JAPANESE), is("🙀𪛊"));
+
+        Message message = MessageUtil.createMessage(MessageLevel.INFO, "message.with.placeholder",
+                MessageUtil.createMessage(MessageLevel.INFO, "sarogetopea.message"), "🙀🙀🙀");
+        assertThat(message.formatMessage(Locale.JAPANESE), is("ここにmessageのメッセージが入る→𪛊𪛊𪛊-🙀🙀🙀"));
+    }
+
+    /**
      * スレッドコンテキストに言語が設定されていない場合、
      * VMのデフォルトロケールの言語が使用されること。
      */

--- a/src/test/java/nablarch/core/message/PropertiesStringResourceLoaderTest.java
+++ b/src/test/java/nablarch/core/message/PropertiesStringResourceLoaderTest.java
@@ -153,13 +153,15 @@ public class PropertiesStringResourceLoaderTest {
     public void testLoadAll_default() throws Exception {
         List<StringResource> result = sut.loadAll();
 
-        assertThat(result.size(), is(4));
+        assertThat(result.size(), is(6));
 
         assertThat(result, containsInAnyOrder(
                 hasProperty("id", is("default.key")),
                 hasProperty("id", is("load.all.key")),
                 hasProperty("id", is("message.with.placeholder")),
-                hasProperty("id", is("message"))
+                hasProperty("id", is("message")),
+                hasProperty("id", is("surrogatepair")),
+                hasProperty("id", is("surrogatepair.message"))
         ));
     }
 

--- a/src/test/resources/messages.properties
+++ b/src/test/resources/messages.properties
@@ -3,4 +3,5 @@ load.all.key=loadAllValue
 
 message=埋め込みメッセージ
 message.with.placeholder=ここにmessageのメッセージが入る→{0}-{1}
-
+sarogetopea = 🙀𪛊
+sarogetopea.message = 𪛊𪛊𪛊

--- a/src/test/resources/messages.properties
+++ b/src/test/resources/messages.properties
@@ -3,5 +3,5 @@ load.all.key=loadAllValue
 
 message=埋め込みメッセージ
 message.with.placeholder=ここにmessageのメッセージが入る→{0}-{1}
-sarogetopea = 🙀𪛊
-sarogetopea.message = 𪛊𪛊𪛊
+surrogatepair = 🙀𪛊
+surrogatepair.message = 𪛊𪛊𪛊


### PR DESCRIPTION
messages.propertiesに設定したサロゲートペアを読み込めることを確認するテストケースを追加