### PR TITLE
公開APIを追加

### DIFF
--- a/src/main/java/nablarch/core/message/BasicStringResource.java
+++ b/src/main/java/nablarch/core/message/BasicStringResource.java
@@ -17,11 +17,11 @@ public class BasicStringResource implements StringResource {
     /**
      * メッセージID。
      */
-    private String id;
+    private final String id;
     /**
      * 言語をキーとした文字列のmap。
      */
-    private Map<String, String> formatMap;
+    private final Map<String, String> formatMap;
 
     /**
      * コンストラクタ。

--- a/src/main/java/nablarch/core/message/BasicStringResource.java
+++ b/src/main/java/nablarch/core/message/BasicStringResource.java
@@ -1,5 +1,7 @@
 package nablarch.core.message;
 
+import nablarch.core.util.annotation.Published;
+
 import java.util.Locale;
 import java.util.Map;
 
@@ -9,6 +11,7 @@ import java.util.Map;
  * @author Koichi Asano
  *
  */
+@Published
 public class BasicStringResource implements StringResource {
 
     /**

--- a/src/test/java/nablarch/core/message/PropertiesStringResourceLoaderTest.java
+++ b/src/test/java/nablarch/core/message/PropertiesStringResourceLoaderTest.java
@@ -6,30 +6,18 @@ import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.CharBuffer;
-import java.nio.charset.UnsupportedCharsetException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Properties;
-
-import nablarch.core.util.FileUtil;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import mockit.Capturing;
 import mockit.Deencapsulation;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.Mocked;
 
 /**
  * {@link PropertiesStringResourceLoader}のテストクラス。


### PR DESCRIPTION
`BasicStringResource`は元々公開APIではありませんでしたが、他APIの拡張時に利用されると考えられるため、公開APIに変更しました。